### PR TITLE
[codex] Fix WebsocketClient teardown and reconnect leaks

### DIFF
--- a/src/fptn-protocol-lib/https/websocket_client/websocket_client.cpp
+++ b/src/fptn-protocol-lib/https/websocket_client/websocket_client.cpp
@@ -25,6 +25,7 @@ namespace fptn::protocol::https {
 
 WebsocketClient::WebsocketClient(Config config, int thread_number)
     : ioc_(thread_number),
+      work_guard_(boost::asio::make_work_guard(ioc_)),
       ctx_(https::utils::CreateNewSslCtx()),
       resolver_(boost::asio::make_strand(ioc_)),
       strand_(boost::asio::make_strand(ioc_)),
@@ -111,12 +112,11 @@ void WebsocketClient::Run() {
       },
       boost::asio::detached);
   try {
-    while (running_ || !was_stopped_) {
-      const std::size_t processed = ioc_.poll_one();
-      if (processed == 0) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
-      }
-    }
+    // Block until Stop() releases the work guard AND every pending handler has
+    // drained (RunReader/RunSender resumptions, socket-close completions, the
+    // watchdog). Draining is what releases their shared_from_this() captures and
+    // breaks the ioc_<->client reference cycle, so the object can be destroyed.
+    ioc_.run();
   } catch (...) {
     SPDLOG_WARN("Exception while running");
   }
@@ -236,6 +236,12 @@ bool WebsocketClient::Stop() {
   if (auto* ssl = ws_.next_layer().native_handle()) {
     https::utils::AttachCertificateVerificationCallbackDelete(ssl);
   }
+
+  // Release the work guard so Run()'s ioc_.run() returns once the cancellations
+  // above have drained. The drain releases the RunReader/RunSender coroutines'
+  // shared_from_this(), breaking the ioc_<->client cycle that previously leaked
+  // the entire client (and its multi-MB buffers) on every reconnect.
+  work_guard_.reset();
 
   was_stopped_ = true;
   SPDLOG_INFO("WebSocket client stopped successfully");

--- a/src/fptn-protocol-lib/https/websocket_client/websocket_client.cpp
+++ b/src/fptn-protocol-lib/https/websocket_client/websocket_client.cpp
@@ -171,40 +171,40 @@ bool WebsocketClient::Stop() {
     SPDLOG_ERROR("Unknown exception during closing write channel");
   }
 
+  // Ungated by was_inited_: cancels an in-flight Connect()-phase async_resolve,
+  // which is otherwise bounded only by the OS DNS timeout, stalling the drain.
   try {
     SPDLOG_INFO("Closing resolver");
-    if (was_inited_) {
-      resolver_.cancel();
-    }
+    resolver_.cancel();
   } catch (const std::exception&) {
     SPDLOG_DEBUG("Exception cancelling resolver");
   } catch (...) {
     SPDLOG_ERROR("Unknown exception during closing resolver");
   }
 
-  // Close TCP connection
+  // Close TCP connection. Ungated by was_inited_ so a Stop() racing the connect
+  // phase actively aborts the in-flight connect/handshake (closing the socket
+  // errors out the pending op) instead of waiting for the beast timeout.
   try {
-    if (was_inited_) {
-      SPDLOG_INFO("Shutting down TCP socket...");
+    SPDLOG_INFO("Shutting down TCP socket...");
 
-      auto& tcp = boost::beast::get_lowest_layer(ws_);
+    auto& tcp = boost::beast::get_lowest_layer(ws_);
+    if (tcp.socket().is_open()) {
       const boost::asio::socket_base::linger linger(true, 0);
       tcp.socket().set_option(linger);
 
-      if (tcp.socket().is_open()) {
-        tcp.socket().shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
-        if (ec && ec != boost::asio::error::not_connected) {
-          SPDLOG_WARN("TCP socket shutdown error: {}", ec.message());
-        } else {
-          SPDLOG_INFO("TCP socket shutdown successfully");
-        }
+      tcp.socket().shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
+      if (ec && ec != boost::asio::error::not_connected) {
+        SPDLOG_WARN("TCP socket shutdown error: {}", ec.message());
+      } else {
+        SPDLOG_INFO("TCP socket shutdown successfully");
+      }
 
-        tcp.socket().close(ec);
-        if (ec) {
-          SPDLOG_WARN("TCP socket close error: {}", ec.message());
-        } else {
-          SPDLOG_INFO("TCP socket closed successfully");
-        }
+      tcp.socket().close(ec);
+      if (ec) {
+        SPDLOG_WARN("TCP socket close error: {}", ec.message());
+      } else {
+        SPDLOG_INFO("TCP socket closed successfully");
       }
     }
   } catch (const boost::system::system_error& err) {

--- a/src/fptn-protocol-lib/https/websocket_client/websocket_client.h
+++ b/src/fptn-protocol-lib/https/websocket_client/websocket_client.h
@@ -94,6 +94,8 @@ class WebsocketClient : public std::enable_shared_from_this<WebsocketClient> {
   std::atomic<bool> ip_assigned_{false};
 
   boost::asio::io_context ioc_;
+  boost::asio::executor_work_guard<boost::asio::io_context::executor_type>
+      work_guard_;
   boost::asio::ssl::context ctx_;
   boost::asio::ip::tcp::resolver resolver_;
 


### PR DESCRIPTION
## Summary
- replace WebsocketClient manual poll loop with an `io_context::run()` drain guarded by an executor work guard
- reset the work guard from `Stop()` after issuing cancellations so pending handlers/coroutines can unwind and release `shared_from_this()` captures
- cancel resolver and close the TCP socket even when `Stop()` races the connect phase, avoiding OS/beast timeout-bound teardown

## Why
On reconnect, watchdog, and user-cancel paths, `Stop()` can run inline on the IO thread. The previous loop could exit before socket-close/cancellation completions drained, leaving reader/sender coroutines alive through `shared_from_this()` captures. Stop during connect could also wait on DNS/connect/handshake timeouts.

## Validation
- `git diff --check upstream/master...HEAD`
- `conan install . --output-folder=build-pr --build=missing -o build_only_fptn_lib=True --settings build_type=Debug -s compiler.cppstd=17`
- `cmake --preset conan-debug && cmake --build --preset conan-debug -j 10`
