### PR TITLE
tls: key the session_id marker with a shared secret (HMAC), dual-accept

### DIFF
--- a/deploy/docker/scripts/token-generator.py
+++ b/deploy/docker/scripts/token-generator.py
@@ -23,7 +23,7 @@ def get_md5_fingerprint(cert_path="/etc/fptn/server.crt"):
         sys.exit(1)
 
 
-def generate_token(username, password, server_ip, service_name, md5_fingerprint, port=443):
+def generate_token(username, password, server_ip, service_name, md5_fingerprint, port=443, session_key=None):
     token_data = {
         "version": 1,
         "service_name": service_name,
@@ -32,6 +32,10 @@ def generate_token(username, password, server_ip, service_name, md5_fingerprint,
         "servers": [{"name": service_name, "host": server_ip, "md5_fingerprint": md5_fingerprint, "port": port}],
         "censored_zone_servers": [],
     }
+    # Shared secret for the keyed TLS session-id marker. Emit only when set so
+    # existing tokens stay unchanged; must match the server's --session-key.
+    if session_key:
+        token_data["session_key"] = session_key
     json_str = json.dumps(token_data, separators=(",", ":"))
     b64_bytes = base64.b64encode(json_str.encode("utf-8"))
     b64_str = b64_bytes.decode("utf-8").rstrip("=")
@@ -46,6 +50,9 @@ def main():
     parser.add_argument("--service-name", default="MyFptnServer", help="VPN service name")
     parser.add_argument("--cert-path", default="/etc/fptn/server.crt", help="Path to server certificate")
     parser.add_argument("--port", type=int, default=443, help="Port number (default: 443)")
+    parser.add_argument("--session-key", default=None,
+                        help="Shared secret for the keyed session-id marker "
+                             "(must match the server's --session-key)")
 
     args = parser.parse_args()
 
@@ -63,6 +70,7 @@ def main():
         service_name=args.service_name,
         md5_fingerprint=md5_fingerprint,
         port=args.port,
+        session_key=args.session_key,
     )
     print(token)
 

--- a/src/fptn-client/config/config_file.cpp
+++ b/src/fptn-client/config/config_file.cpp
@@ -84,10 +84,14 @@ bool ConfigFile::Parse() {
     service_name_ = config.at("service_name").get<std::string>();
     username_ = config.at("username").get<std::string>();
     password_ = config.at("password").get<std::string>();
+    // Optional: shared secret for the keyed session-id marker. Absent in older
+    // tokens -> stays empty -> client keeps the legacy marker.
+    session_key_ = config.value("session_key", std::string{});
     for (const auto& server : config.at("servers")) {
       ServerInfo s(server.at("name").get<std::string>(),
           server.at("host").get<std::string>(), server.at("port").get<int>(),
           server.at("md5_fingerprint").get<std::string>());
+      s.session_key = session_key_;
       servers_.push_back(s);
     }
     if (servers_.empty()) {
@@ -140,6 +144,10 @@ const std::string& ConfigFile::GetUsername() const noexcept {
 
 const std::string& ConfigFile::GetPassword() const noexcept {
   return password_;
+}
+
+const std::string& ConfigFile::GetSessionKey() const noexcept {
+  return session_key_;
 }
 
 const std::vector<ServerInfo>& ConfigFile::GetServers() const noexcept {

--- a/src/fptn-client/config/config_file.h
+++ b/src/fptn-client/config/config_file.h
@@ -44,6 +44,7 @@ class ConfigFile final {
   const std::string& GetServiceName() const noexcept;
   const std::string& GetUsername() const noexcept;
   const std::string& GetPassword() const noexcept;
+  const std::string& GetSessionKey() const noexcept;
   const std::vector<fptn::utils::speed_estimator::ServerInfo>& GetServers()
       const noexcept;
 
@@ -56,6 +57,7 @@ class ConfigFile final {
   std::string service_name_;
   std::string username_;
   std::string password_;
+  std::string session_key_;
   std::vector<fptn::utils::speed_estimator::ServerInfo> servers_;
 };
 }  // namespace fptn::config

--- a/src/fptn-client/fptn-client-cli.cpp
+++ b/src/fptn-client/fptn-client-cli.cpp
@@ -412,6 +412,7 @@ int main(int argc, char* argv[]) {
             .tun_interface_address_ipv6 = tun_interface_address_ipv6,
             .sni = sni,
             .expected_md5_fingerprint = selected_server.md5_fingerprint,
+            .session_key = selected_server.session_key,
             .censorship_strategy = censorship_strategy,
             .on_connected_callback = nullptr,
             .new_ip_pkt_callback = nullptr});

--- a/src/fptn-client/gui/settingsmodel/settingsmodel.cpp
+++ b/src/fptn-client/gui/settingsmodel/settingsmodel.cpp
@@ -179,6 +179,7 @@ void SettingsModel::Load(bool dont_load_server) {
       service.service_name = jsonservice_obj["service_name"].toString();
       service.username = jsonservice_obj["username"].toString();
       service.password = jsonservice_obj["password"].toString();
+      service.session_key = jsonservice_obj["session_key"].toString();
 
       if (!dont_load_server) {
         service.servers = ParseServers(jsonservice_obj["servers"].toArray());
@@ -370,6 +371,7 @@ bool SettingsModel::Save() {
     service_obj["service_name"] = service.service_name;
     service_obj["username"] = service.username;
     service_obj["password"] = service.password;
+    service_obj["session_key"] = service.session_key;
 
     QJsonArray servers_array;
     for (const auto& server : service.servers) {
@@ -447,6 +449,7 @@ ServiceConfig SettingsModel::ParseToken(const QString& token) {
   service.service_name = json_object["service_name"].toString();
   service.username = json_object["username"].toString();
   service.password = json_object["password"].toString();
+  service.session_key = json_object["session_key"].toString();
 
   service.servers = ParseServers(json_object["servers"].toArray());
   if (json_object.contains("censored_zone_servers")) {

--- a/src/fptn-client/gui/settingsmodel/settingsmodel.h
+++ b/src/fptn-client/gui/settingsmodel/settingsmodel.h
@@ -98,6 +98,8 @@ struct ServiceConfig {
   QString service_name;
   QString username;
   QString password;
+  // Deployment-wide shared secret S for the keyed session-id marker (optional).
+  QString session_key;
   QVector<ServerConfig> servers;
   QVector<ServerConfig> censored_zone_servers;
   QString language;

--- a/src/fptn-client/gui/sni_autoscan_dialog/sni_autoscan_dialog.cpp
+++ b/src/fptn-client/gui/sni_autoscan_dialog/sni_autoscan_dialog.cpp
@@ -247,9 +247,11 @@ void SniAutoscanDialog::WorkerThread(int thread_id) {
       bool http_ok = false;
 
       constexpr int kHandshakeTimeout = 2;
+      // SNI reachability probe: no keyed session-id marker here (the shared
+      // secret is service-level and not carried by this diagnostic scanner).
       fptn::protocol::https::ApiClient client(server.host.toStdString(),
           server.port, sni, server.md5_fingerprint.toStdString(),
-          protocol::https::CensorshipStrategy::kSni);
+          /*session_key=*/"", protocol::https::CensorshipStrategy::kSni);
 
       handshake_ok = client.TestHandshake(kHandshakeTimeout);
       if (handshake_ok) {

--- a/src/fptn-client/gui/tray/tray.cpp
+++ b/src/fptn-client/gui/tray/tray.cpp
@@ -361,6 +361,7 @@ void TrayApp::UpdateTrayMenu() {
                 cfg_server.password = service.password.toStdString();
                 cfg_server.md5_fingerprint =
                     server.md5_fingerprint.toStdString();
+                cfg_server.session_key = service.session_key.toStdString();
               }
               selected_server_ = cfg_server;
               onConnectToServer();
@@ -396,6 +397,8 @@ void TrayApp::UpdateTrayMenu() {
                     cfg_server.password = service.password.toStdString();
                     cfg_server.md5_fingerprint =
                         server.md5_fingerprint.toStdString();
+                    cfg_server.session_key =
+                        service.session_key.toStdString();
                   }
                   selected_server_ = cfg_server;
                   onConnectToServer();
@@ -879,6 +882,7 @@ bool TrayApp::startVpn(QString& err_msg) {
           cfg_server.username = service.username.toStdString();
           cfg_server.password = service.password.toStdString();
           cfg_server.md5_fingerprint = s.md5_fingerprint.toStdString();
+          cfg_server.session_key = service.session_key.toStdString();
         }
         config.AddServer(cfg_server);
       }
@@ -913,6 +917,7 @@ bool TrayApp::startVpn(QString& err_msg) {
               common::network::IPv6Address(FPTN_CLIENT_DEFAULT_ADDRESS_IP6),
           .sni = sni,
           .expected_md5_fingerprint = selected_server_.md5_fingerprint,
+          .session_key = selected_server_.session_key,
           .censorship_strategy = censorship_strategy,
           .on_connected_callback = nullptr,
           .new_ip_pkt_callback = nullptr});

--- a/src/fptn-client/utils/speed_estimator/server_info.h
+++ b/src/fptn-client/utils/speed_estimator/server_info.h
@@ -22,6 +22,12 @@ struct ServerInfo {
   std::string password;
   std::string service_name;
 
+  // Deployment-wide shared secret S for the keyed TLS session-id marker.
+  // Empty keeps the legacy (unkeyed) marker. Carried per-server so it reaches
+  // every ApiClient/WebsocketClient the same way md5_fingerprint does; the
+  // value itself is service-level (see ConfigFile::Parse).
+  std::string session_key;
+
   ServerInfo() : port(0), is_using(false) {}
 
   ServerInfo(std::string _name,

--- a/src/fptn-client/utils/speed_estimator/speed_estimator.cpp
+++ b/src/fptn-client/utils/speed_estimator/speed_estimator.cpp
@@ -39,8 +39,8 @@ std::uint64_t GetDownloadTimeMs(const ServerInfo& server,
     fptn::protocol::https::CensorshipStrategy censorship_strategy) {
   try {
     auto const start = std::chrono::high_resolution_clock::now();
-    ApiClient cli(
-        server.host, server.port, sni, md5_fingerprint, censorship_strategy);
+    ApiClient cli(server.host, server.port, sni, md5_fingerprint,
+        server.session_key, censorship_strategy);
     auto const resp = cli.Get(common::api::kApiTestFileBinUrl, timeout);
     if (resp.code == 200) {
       auto const end = std::chrono::high_resolution_clock::now();
@@ -144,7 +144,7 @@ std::optional<LoginResult> FindServerByLogin(const std::string& sni,
             fmt::format(R"({{ "username": "{}", "password": "{}" }})",
                 server.username, server.password);
         ApiClient cli(server.host, server.port, sni, server.md5_fingerprint,
-            censorship_strategy);
+            server.session_key, censorship_strategy);
         const auto resp = cli.Post(
             common::api::kApiLoginUrl, body, "application/json", timeout_sec);
         if (resp.code == 200) {

--- a/src/fptn-client/vpn/http/client.cpp
+++ b/src/fptn-client/vpn/http/client.cpp
@@ -53,7 +53,8 @@ bool Client::Login(
 
   const std::string ip = config_.server_ip.ToString();
   ApiClient cli(ip, config_.server_port, config_.sni,
-      config_.expected_md5_fingerprint, config_.censorship_strategy);
+      config_.expected_md5_fingerprint, config_.session_key,
+      config_.censorship_strategy);
 
   constexpr int kMaxRetries = 3;
   for (int attempt = 0; attempt < kMaxRetries; ++attempt) {
@@ -109,7 +110,8 @@ std::pair<IPv4Address, IPv6Address> Client::GetDns() {
 
   const std::string ip = config_.server_ip.ToString();
   ApiClient cli(ip, config_.server_port, config_.sni,
-      config_.expected_md5_fingerprint, config_.censorship_strategy);
+      config_.expected_md5_fingerprint, config_.session_key,
+      config_.censorship_strategy);
 
   constexpr int kMaxRetries = 3;
   for (int attempt = 0; attempt < kMaxRetries; ++attempt) {

--- a/src/fptn-protocol-lib/https/api_client/api_client.cpp
+++ b/src/fptn-protocol-lib/https/api_client/api_client.cpp
@@ -314,11 +314,13 @@ ApiClient::ApiClient(std::string host,
     int port,
     std::string sni,
     std::string md5_fingerprint,
+    std::string session_key,
     CensorshipStrategy censorship_strategy)
     : host_(std::move(host)),
       port_(port),
       sni_(std::move(sni)),
       expected_md5_fingerprint_(std::move(md5_fingerprint)),
+      session_key_(std::move(session_key)),
       censorship_strategy_(censorship_strategy) {}  // NOLINT
 
 Response ApiClient::Get(const std::string& handle, int timeout) const {
@@ -402,7 +404,7 @@ boost::asio::awaitable<Response> ApiClient::AsyncPost(const std::string& handle,
       co_return Response{"", 600, ec.message()};
     }
 
-    utils::SetHandshakeSessionID(stream.native_handle());
+    utils::SetHandshakeSessionID(stream.native_handle(), session_key_);
     utils::SetHandshakeSni(stream.native_handle(), sni_);
     ctx.set_verify_mode(boost::asio::ssl::verify_none);
 
@@ -489,8 +491,8 @@ bool ApiClient::TestHandshake(int timeout) const {
 }
 
 ApiClient ApiClient::Clone() const {
-  ApiClient temp_client(
-      host_, port_, sni_, expected_md5_fingerprint_, censorship_strategy_);
+  ApiClient temp_client(host_, port_, sni_, expected_md5_fingerprint_,
+      session_key_, censorship_strategy_);
   return temp_client;
 }
 
@@ -614,7 +616,7 @@ Response ApiClient::GetImpl(const std::string& handle, int timeout) const {
             std::make_shared<protocol::https::obfuscator::TlsObfuscator2>());
       }
 
-      utils::SetHandshakeSessionID(stream.native_handle());
+      utils::SetHandshakeSessionID(stream.native_handle(), session_key_);
       utils::SetHandshakeSni(stream.native_handle(), sni_);
       if (!expected_md5_fingerprint_.empty()) {
         ssl = stream.native_handle();
@@ -782,7 +784,7 @@ Response ApiClient::PostImpl(const std::string& handle,
             std::make_shared<protocol::https::obfuscator::TlsObfuscator2>());
       }
 
-      utils::SetHandshakeSessionID(stream.native_handle());
+      utils::SetHandshakeSessionID(stream.native_handle(), session_key_);
       utils::SetHandshakeSni(stream.native_handle(), sni_);
       if (!expected_md5_fingerprint_.empty()) {
         ssl = stream.native_handle();
@@ -955,7 +957,7 @@ bool ApiClient::TestHandshakeImpl(int timeout) const {
             "handshake");
       }
     }
-    utils::SetHandshakeSessionID(stream.native_handle());
+    utils::SetHandshakeSessionID(stream.native_handle(), session_key_);
     utils::SetHandshakeSni(stream.native_handle(), sni_);
 
     if (!expected_md5_fingerprint_.empty()) {
@@ -1132,15 +1134,15 @@ std::vector<std::uint8_t> ApiClient::GenerateHandshakePacket() const {
       break;
     default:
       SPDLOG_DEBUG("Using fallback handshake generator for SNI: {}", sni_);
-      return utils::GenerateDecoyTlsHandshake(sni_);
+      return utils::GenerateDecoyTlsHandshake(sni_, session_key_);
   }
 
   SPDLOG_INFO("Generating handshake for SNI: {}", sni_);
 
-  const auto session_id = utils::GenerateDecoyTlsSessionId2();
+  const auto session_id = utils::GenerateDecoyTlsSessionId2(session_key_);
   if (!session_id.has_value()) {
     SPDLOG_WARN("Session ID generation failed for handshake, using fallback");
-    return utils::GenerateDecoyTlsHandshake(sni_);
+    return utils::GenerateDecoyTlsHandshake(sni_, session_key_);
   }
 
   const auto handshake =
@@ -1148,7 +1150,7 @@ std::vector<std::uint8_t> ApiClient::GenerateHandshakePacket() const {
   if (!handshake.has_value()) {
     SPDLOG_WARN(
         "Handshake generation failed for SNI: {}, using fallback", sni_);
-    return utils::GenerateDecoyTlsHandshake(sni_);
+    return utils::GenerateDecoyTlsHandshake(sni_, session_key_);
   }
 
   SPDLOG_INFO("Handshake generated: SNI={}, size={} bytes", sni_,

--- a/src/fptn-protocol-lib/https/api_client/api_client.h
+++ b/src/fptn-protocol-lib/https/api_client/api_client.h
@@ -61,6 +61,7 @@ class ApiClient {
       int port,
       std::string sni,
       std::string md5_fingerprint,
+      std::string session_key,
       CensorshipStrategy censorship_strategy);
 
   Response Get(const std::string& handle, int timeout = 5) const;
@@ -98,6 +99,7 @@ class ApiClient {
   const int port_;
   const std::string sni_;
   const std::string expected_md5_fingerprint_;
+  const std::string session_key_;
   const CensorshipStrategy censorship_strategy_;
 };
 

--- a/src/fptn-protocol-lib/https/utils/tls/tls.cpp
+++ b/src/fptn-protocol-lib/https/utils/tls/tls.cpp
@@ -19,9 +19,9 @@ Distributed under the MIT License (https://opensource.org/licenses/MIT)
 #include <fmt/format.h>  // NOLINT(build/include_order)
 #include <nlohmann/json.hpp>
 #include <openssl/evp.h>    // NOLINT(build/include_order)
+#include <openssl/hmac.h>   // NOLINT(build/include_order)
 #include <openssl/md5.h>    // NOLINT(build/include_order)
 #include <openssl/rand.h>   // NOLINT(build/include_order)
-#include <openssl/sha.h>    // NOLINT(build/include_order)
 #include <openssl/ssl.h>    // NOLINT(build/include_order)
 #include <spdlog/spdlog.h>  // NOLINT(build/include_order)
 
@@ -77,104 +77,115 @@ std::string GenerateFptnKey(std::uint32_t timestamp) {
       "Error generate Session ID");
 }
 
-bool SetDecoyHandshakeSessionID(SSL* ssl) {
+std::string GenerateFptnKeyKeyed(
+    std::uint32_t timestamp, const std::string& secret) {
+  const std::uint32_t be = htonl(timestamp);
+  unsigned char out[EVP_MAX_MD_SIZE] = {0};
+  unsigned int outlen = 0;
+  if (secret.empty() ||
+      ::HMAC(EVP_sha256(),
+          reinterpret_cast<const unsigned char*>(secret.data()),
+          static_cast<int>(secret.size()),
+          reinterpret_cast<const unsigned char*>(&be), sizeof(be), out,
+          &outlen) == nullptr ||
+      outlen < kFptnKeyLength) {
+    throw boost::beast::system_error(
+        boost::beast::error_code(static_cast<int>(::ERR_get_error()),
+            boost::asio::error::get_ssl_category()),
+        "Error generate keyed Session ID");
+  }
+  return std::string(reinterpret_cast<const char*>(out), kFptnKeyLength);
+}
+
+namespace {
+// True if recv_key matches the legacy time marker (when accept_legacy) or a
+// keyed marker for any of `secrets`, within the +-5s clock window.
+bool MarkerMatches(const std::string& recv_key,
+    const std::vector<std::string>& secrets,
+    bool accept_legacy) {
+  const auto now = fptn::time::TimeProvider::Instance()->NowTimestamp();
+  constexpr std::uint32_t kTimeShiftSeconds = 10;  // ten seconds
+  const std::uint32_t base = now + (kTimeShiftSeconds / 2);
+  for (std::uint32_t shift = 0; shift <= kTimeShiftSeconds; ++shift) {
+    const std::uint32_t ts = base - shift;
+    if (accept_legacy && recv_key == GenerateFptnKey(ts)) {
+      return true;
+    }
+    for (const auto& secret : secrets) {
+      if (!secret.empty() && recv_key == GenerateFptnKeyKeyed(ts, secret)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+}  // namespace
+
+bool SetDecoyHandshakeSessionID(SSL* ssl, const std::string& secret) {
   // random
   std::uint8_t session_id[kSessionLen] = {0};
   if (::RAND_bytes(session_id, sizeof(session_id)) != 1) {
     return false;
   }
 
-  // copy timestamp
+  // copy timestamp marker (keyed when a secret is provided, else legacy)
   const auto timestamp = fptn::time::TimeProvider::Instance()->NowTimestamp();
-  const std::string key = GenerateFptnKey(timestamp);
+  const std::string key = secret.empty()
+                              ? GenerateFptnKey(timestamp)
+                              : GenerateFptnKeyKeyed(timestamp, secret);
   std::memcpy(
       &session_id[kDecoyHandshakeSessionIDShift], key.c_str(), key.size());
   return 0 != ::SSL_set_tls_hello_custom_session_id(
                   ssl, session_id, sizeof(session_id));
 }
 
-bool IsDecoyHandshakeSessionID(
-    const std::uint8_t* session, std::size_t session_len) {
+bool IsDecoyHandshakeSessionID(const std::uint8_t* session,
+    std::size_t session_len,
+    const std::vector<std::string>& secrets,
+    bool accept_legacy) {
   (void)session_len;
   char data[kFptnKeyLength] = {0};
   std::memcpy(&data, &session[kDecoyHandshakeSessionIDShift], sizeof(data));
   const std::string recv_key(data, sizeof(data));
-
-  const auto now_timestamp =
-      fptn::time::TimeProvider::Instance()->NowTimestamp();
-
-  constexpr std::uint32_t kTimeShiftSeconds = 10;  // ten seconds
-
-  const std::uint32_t timestamp = now_timestamp + (kTimeShiftSeconds / 2);
-
-  for (std::uint32_t shift = 0; shift <= kTimeShiftSeconds; shift++) {
-    const std::string key = GenerateFptnKey(timestamp - shift);
-    if (recv_key == key) {
-      return true;
-    }
-  }
-  return false;
+  return MarkerMatches(recv_key, secrets, accept_legacy);
 }
 
-bool IsDecoyHandshakeSessionID2(
-    const std::uint8_t* session, std::size_t session_len) {
+bool IsDecoyHandshakeSessionID2(const std::uint8_t* session,
+    std::size_t session_len,
+    const std::vector<std::string>& secrets,
+    bool accept_legacy) {
   (void)session_len;
   char data[kFptnKeyLength] = {0};
   std::memcpy(&data, &session[kDecoyHandshakeSessionIDShift2], sizeof(data));
   const std::string recv_key(data, sizeof(data));
-
-  const auto now_timestamp =
-      fptn::time::TimeProvider::Instance()->NowTimestamp();
-
-  constexpr std::uint32_t kTimeShiftSeconds = 10;  // ten seconds
-
-  const std::uint32_t timestamp = now_timestamp + (kTimeShiftSeconds / 2);
-
-  for (std::uint32_t shift = 0; shift <= kTimeShiftSeconds; shift++) {
-    const std::string key = GenerateFptnKey(timestamp - shift);
-    if (recv_key == key) {
-      return true;
-    }
-  }
-  return false;
+  return MarkerMatches(recv_key, secrets, accept_legacy);
 }
 
-bool SetHandshakeSessionID(SSL* ssl) {
+bool SetHandshakeSessionID(SSL* ssl, const std::string& secret) {
   // random
   std::uint8_t session_id[kSessionLen] = {0};
   if (::RAND_bytes(session_id, sizeof(session_id)) != 1) {
     return false;
   }
-  // copy timestamp
+  // copy timestamp marker (keyed when a secret is provided, else legacy)
   const auto timestamp = fptn::time::TimeProvider::Instance()->NowTimestamp();
-
-  const std::string key = GenerateFptnKey(timestamp);
+  const std::string key = secret.empty()
+                              ? GenerateFptnKey(timestamp)
+                              : GenerateFptnKeyKeyed(timestamp, secret);
   std::memcpy(&session_id[kSessionLen - key.size()], key.c_str(), key.size());
 
   return 0 != ::SSL_set_tls_hello_custom_session_id(
                   ssl, session_id, sizeof(session_id));
 }
 
-bool IsFptnClientSessionID(
-    const std::uint8_t* session, std::size_t session_len) {
+bool IsFptnClientSessionID(const std::uint8_t* session,
+    std::size_t session_len,
+    const std::vector<std::string>& secrets,
+    bool accept_legacy) {
   char data[kFptnKeyLength] = {0};
   std::memcpy(&data, &session[session_len - sizeof(data)], sizeof(data));
   const std::string recv_key(data, sizeof(data));
-
-  const auto now_timestamp =
-      fptn::time::TimeProvider::Instance()->NowTimestamp();
-
-  constexpr std::uint32_t kTimeShiftSeconds = 10;  // ten seconds
-
-  const std::uint32_t timestamp = now_timestamp + (kTimeShiftSeconds / 2);
-
-  for (std::uint32_t shift = 0; shift <= kTimeShiftSeconds; shift++) {
-    const std::string key = GenerateFptnKey(timestamp - shift);
-    if (recv_key == key) {
-      return true;
-    }
-  }
-  return false;
+  return MarkerMatches(recv_key, secrets, accept_legacy);
 }
 
 bool SetHandshakeSni(SSL* ssl, const std::string& sni) {
@@ -298,7 +309,8 @@ std::string GetCertificateMD5Fingerprint(const X509* cert) {
   return ss.str();
 }
 
-std::vector<std::uint8_t> GenerateDecoyTlsHandshake(const std::string& sni) {
+std::vector<std::uint8_t> GenerateDecoyTlsHandshake(
+    const std::string& sni, const std::string& secret) {
   std::vector<std::uint8_t> handshake_data;
   try {
     SSL_CTX* ssl_ctx = CreateNewSslCtx();
@@ -309,7 +321,7 @@ std::vector<std::uint8_t> GenerateDecoyTlsHandshake(const std::string& sni) {
     ::SSL_set_bio(ssl, bio_in, bio_out);
 
     SetHandshakeSni(ssl, sni);
-    SetDecoyHandshakeSessionID(ssl);
+    SetDecoyHandshakeSessionID(ssl, secret);
     // X25519MLKEM768 (ctx default) triggers HelloRetryRequest on servers
     // that don't support post-quantum key exchange, deadlocking the decoy read.
     ::SSL_set1_groups_list(ssl, "X25519:secp256r1:secp384r1");
@@ -368,15 +380,19 @@ std::optional<std::array<std::uint8_t, 32>> GenerateDecoyTlsSessionId() {
   return session_id;
 }
 
-std::optional<std::array<std::uint8_t, 32>> GenerateDecoyTlsSessionId2() {
+std::optional<std::array<std::uint8_t, 32>> GenerateDecoyTlsSessionId2(
+    const std::string& secret) {
   std::array<std::uint8_t, kSessionLen> session_id{};
   if (::RAND_bytes(session_id.data(), session_id.size()) != 1) {
     return std::nullopt;
   }
 
-  // Get timestamp and generate key
+  // Get timestamp and generate key (keyed when a secret is provided, else
+  // legacy)
   const auto timestamp = fptn::time::TimeProvider::Instance()->NowTimestamp();
-  const std::string key = GenerateFptnKey(timestamp);
+  const std::string key = secret.empty()
+                              ? GenerateFptnKey(timestamp)
+                              : GenerateFptnKeyKeyed(timestamp, secret);
   const std::size_t copy_size =
       std::min(key.size(), session_id.size() - kDecoyHandshakeSessionIDShift2);
   std::memcpy(session_id.data() + kDecoyHandshakeSessionIDShift2, key.c_str(),

--- a/src/fptn-protocol-lib/https/utils/tls/tls.h
+++ b/src/fptn-protocol-lib/https/utils/tls/tls.h
@@ -20,20 +20,40 @@ namespace fptn::protocol::https::utils {
 std::string GetSHA1Hash(std::uint32_t number);
 std::string GenerateFptnKey(std::uint32_t timestamp);
 
-bool SetDecoyHandshakeSessionID(SSL* ssl);
+// Keyed marker: HMAC-SHA256(secret, be32(timestamp))[0:kFptnKeyLength].
+// `secret` is the deployment-wide shared session key S, distributed to clients
+// in the connection token and configured on the server. Unlike the legacy
+// GenerateFptnKey (which is only SHA1(time) and therefore computable by anyone,
+// incl. a censor), a keyed marker cannot be produced or recognised without S.
+std::string GenerateFptnKeyKeyed(
+    std::uint32_t timestamp, const std::string& secret);
 
+// Client-side marker setters. When `secret` is empty they fall back to the
+// legacy (unkeyed, time-only) marker for backward compatibility.
+bool SetDecoyHandshakeSessionID(SSL* ssl, const std::string& secret = "");
+
+// Server-side validators. `secrets` = the configured shared session key(s) S;
+// more than one may be supplied so a new key can be rolled out before the old
+// one is retired (rotation). accept_legacy=true keeps accepting old unkeyed
+// clients during the migration window; set to false once all clients are
+// upgraded to close the time-based fingerprint.
 // DEPRECATED
-bool IsDecoyHandshakeSessionID(
-    const std::uint8_t* session, std::size_t session_len);
+bool IsDecoyHandshakeSessionID(const std::uint8_t* session,
+    std::size_t session_len,
+    const std::vector<std::string>& secrets = {},
+    bool accept_legacy = true);
 
+bool IsDecoyHandshakeSessionID2(const std::uint8_t* session,
+    std::size_t session_len,
+    const std::vector<std::string>& secrets = {},
+    bool accept_legacy = true);
 
-bool IsDecoyHandshakeSessionID2(
-    const std::uint8_t* session, std::size_t session_len);
+bool SetHandshakeSessionID(SSL* ssl, const std::string& secret = "");
 
-bool SetHandshakeSessionID(SSL* ssl);
-
-bool IsFptnClientSessionID(
-    const std::uint8_t* session, std::size_t session_len);
+bool IsFptnClientSessionID(const std::uint8_t* session,
+    std::size_t session_len,
+    const std::vector<std::string>& secrets = {},
+    bool accept_legacy = true);
 
 bool SetHandshakeSni(SSL* ssl, const std::string& sni);
 
@@ -43,12 +63,16 @@ std::string ChromeCiphers();
 
 std::string GetCertificateMD5Fingerprint(const X509* cert);
 
-std::vector<std::uint8_t> GenerateDecoyTlsHandshake(const std::string& sni);
+// `secret` (the shared session key S) keys the embedded session-id marker;
+// empty keeps the legacy time-only marker.
+std::vector<std::uint8_t> GenerateDecoyTlsHandshake(
+    const std::string& sni, const std::string& secret = "");
 
 // DEPRECATED
 std::optional<std::array<std::uint8_t, 32>> GenerateDecoyTlsSessionId();
 
-std::optional<std::array<std::uint8_t, 32>> GenerateDecoyTlsSessionId2();
+std::optional<std::array<std::uint8_t, 32>> GenerateDecoyTlsSessionId2(
+    const std::string& secret = "");
 
 // Callbacks
 using CertificateVerificationCallback = std::function<bool(const std::string&)>;

--- a/src/fptn-protocol-lib/https/websocket_client/websocket_client.cpp
+++ b/src/fptn-protocol-lib/https/websocket_client/websocket_client.cpp
@@ -48,7 +48,7 @@ WebsocketClient::WebsocketClient(Config config, int thread_number)
       config_(std::move(config)) {
   auto* ssl = ws_.next_layer().native_handle();
   https::utils::SetHandshakeSni(ssl, config_.sni);
-  https::utils::SetHandshakeSessionID(ssl);
+  https::utils::SetHandshakeSessionID(ssl, config_.session_key);
 
   // Set SSL buffer sizes
   SSL_set_mode(ssl, SSL_MODE_RELEASE_BUFFERS);
@@ -868,13 +868,14 @@ std::vector<std::uint8_t> WebsocketClient::GenerateHandshakePacket() const {
       break;
     default:
       SPDLOG_DEBUG("Using fallback handshake generator for SNI: {}", sni_);
-      return utils::GenerateDecoyTlsHandshake(config_.sni);
+      return utils::GenerateDecoyTlsHandshake(config_.sni, config_.session_key);
   }
 
-  const auto session_id = utils::GenerateDecoyTlsSessionId2();
+  const auto session_id =
+      utils::GenerateDecoyTlsSessionId2(config_.session_key);
   if (!session_id.has_value()) {
     SPDLOG_WARN("Session ID generation failed");
-    return utils::GenerateDecoyTlsHandshake(config_.sni);
+    return utils::GenerateDecoyTlsHandshake(config_.sni, config_.session_key);
   }
 
   const auto handshake =
@@ -882,7 +883,7 @@ std::vector<std::uint8_t> WebsocketClient::GenerateHandshakePacket() const {
   if (!handshake.has_value()) {
     SPDLOG_WARN(
         "Handshake generation failed for SNI: {}, using fallback", config_.sni);
-    return utils::GenerateDecoyTlsHandshake(config_.sni);
+    return utils::GenerateDecoyTlsHandshake(config_.sni, config_.session_key);
   }
 
   SPDLOG_INFO("Handshake generated: SNI={}, size={} bytes", config_.sni,

--- a/src/fptn-protocol-lib/https/websocket_client/websocket_client.h
+++ b/src/fptn-protocol-lib/https/websocket_client/websocket_client.h
@@ -54,6 +54,7 @@ class WebsocketClient : public std::enable_shared_from_this<WebsocketClient> {
     std::string sni;
     std::string access_token;
     std::string expected_md5_fingerprint;
+    std::string session_key;
     CensorshipStrategy censorship_strategy;
     OnConnectedCallback on_connected_callback;
     OnIPRecvPacketCallback new_ip_pkt_callback;

--- a/src/fptn-server/config/server_config.cpp
+++ b/src/fptn-server/config/server_config.cpp
@@ -118,6 +118,20 @@ ServerConfig::ServerConfig(int argc, char* argv[])
           "Enable detection of non-FPTN clients or probing attempts during SSL "
           "handshake. ")
       .default_value("false");
+  args_.add_argument("--session-key")
+      .help(
+          "Shared secret(s) S for the keyed TLS session-id marker "
+          "(HMAC-SHA256). Without a secret the marker is only SHA1(time) and "
+          "can be recomputed by any observer. Comma-separated to accept "
+          "multiple keys at once for rotation. Must match the 'session_key' in "
+          "the clients' tokens. Empty (default): keep the legacy marker.")
+      .default_value("");
+  args_.add_argument("--session-id-accept-legacy")
+      .help(
+          "Keep accepting the legacy (unkeyed) session-id marker alongside the "
+          "keyed one during migration. Set to 'false' once all clients use a "
+          "session key to close the time-based fingerprint.")
+      .default_value("true");
   args_.add_argument("--default-proxy-domain")
       .help("Default domain for proxying non-VPN clients.")
       .default_value(FPTN_DEFAULT_SNI);
@@ -224,6 +238,18 @@ int ServerConfig::RemoteServerAuthPort() const {
 
 bool ServerConfig::EnableDetectProbing() const {
   return ParseBoolean(args_.get<std::string>("--enable-detect-probing"));
+}
+
+std::vector<std::string> ServerConfig::SessionKeys() const {
+  const auto keys = args_.get<std::string>("--session-key");
+  if (keys.empty()) {
+    return {};
+  }
+  return common::utils::SplitCommaSeparated(keys);
+}
+
+bool ServerConfig::SessionIdAcceptLegacy() const {
+  return ParseBoolean(args_.get<std::string>("--session-id-accept-legacy"));
 }
 
 [[nodiscard]]

--- a/src/fptn-server/config/server_config.h
+++ b/src/fptn-server/config/server_config.h
@@ -51,6 +51,12 @@ class ServerConfig {
 
   [[nodiscard]] bool EnableDetectProbing() const;
 
+  // Shared secret(s) S for the keyed TLS session-id marker. Empty = keep the
+  // legacy time-only marker. More than one key allows rotation.
+  [[nodiscard]] std::vector<std::string> SessionKeys() const;
+  // Whether to keep accepting the legacy (unkeyed) marker during migration.
+  [[nodiscard]] bool SessionIdAcceptLegacy() const;
+
   [[nodiscard]] std::string DefaultProxyDomain() const;
   [[nodiscard]] std::vector<std::string> AllowedSniList() const;
 

--- a/src/fptn-server/fptn-server.cpp
+++ b/src/fptn-server/fptn-server.cpp
@@ -110,7 +110,9 @@ int main(int argc, char* argv[]) {
         /* sessions */
         config->MaxActiveSessionsPerUser(),
         /* External IPs */
-        config->ServerExternalIPs());
+        config->ServerExternalIPs(),
+        /* keyed session-id marker */
+        config->SessionKeys(), config->SessionIdAcceptLegacy());
 
     /* init packet filter */
     auto filter_manager = std::make_shared<fptn::filter::Manager>();
@@ -136,6 +138,7 @@ int main(int argc, char* argv[]) {
         "DETECT_PROBING:    {}\n"
         "DEFAULT_PROXY_DOMAIN: {}\n"
         "ALLOWED_SNI_LIST:     {}\n"
+        "SESSION_ID_MARKER:    {}\n"
         "MAX_ACTIVE_SESSIONS_PER_USER: {}\n",
         FPTN_VERSION,
         // Network settings
@@ -147,6 +150,11 @@ int main(int argc, char* argv[]) {
         config->EnableDetectProbing() ? "YES" : "NO",
         config->DefaultProxyDomain(),
         fmt::format("[{}]", fmt::join(config->AllowedSniList(), ", ")),
+        // Session-id marker mode
+        config->SessionKeys().empty()
+            ? "legacy (unkeyed)"
+            : (config->SessionIdAcceptLegacy() ? "keyed + legacy (migration)"
+                                               : "keyed only"),
         // max session
         config->MaxActiveSessionsPerUser());
 

--- a/src/fptn-server/web/listener/listener.cpp
+++ b/src/fptn-server/web/listener/listener.cpp
@@ -31,6 +31,8 @@ Listener::Listener(std::uint16_t port,
     fptn::common::jwt_token::TokenManagerSPtr token_manager,
     HandshakeCacheManagerSPtr handshake_cache_manager,
     std::string server_external_ips,
+    std::vector<std::string> session_keys,
+    bool session_id_accept_legacy,
     WebSocketOpenConnectionCallback ws_open_callback,
     WebSocketNewIPPacketCallback ws_new_ippacket_callback,
     WebSocketCloseConnectionCallback ws_close_callback)
@@ -43,6 +45,8 @@ Listener::Listener(std::uint16_t port,
       token_manager_(std::move(token_manager)),
       handshake_cache_manager_(std::move(handshake_cache_manager)),
       server_external_ips_(std::move(server_external_ips)),
+      session_keys_(std::move(session_keys)),
+      session_id_accept_legacy_(session_id_accept_legacy),
       ws_open_callback_(std::move(ws_open_callback)),
       ws_new_ippacket_callback_(std::move(ws_new_ippacket_callback)),
       ws_close_callback_(std::move(ws_close_callback)),
@@ -105,7 +109,8 @@ boost::asio::awaitable<void> Listener::Run() {
         auto session = std::make_shared<Session>(
             // probing settings
             enable_detect_probing_, default_proxy_domain_, allowed_sni_list_,
-            server_external_ips_, std::move(socket), ctx_,
+            server_external_ips_, session_keys_, session_id_accept_legacy_,
+            std::move(socket), ctx_,
             // handlers
             api_handles_, handshake_cache_manager_, ws_open_callback_,
             ws_new_ippacket_callback_, ws_close_callback_);

--- a/src/fptn-server/web/listener/listener.h
+++ b/src/fptn-server/web/listener/listener.h
@@ -34,6 +34,8 @@ class Listener final {
       fptn::common::jwt_token::TokenManagerSPtr token_manager,
       HandshakeCacheManagerSPtr handshake_cache_manager,
       std::string server_external_ips,
+      std::vector<std::string> session_keys,
+      bool session_id_accept_legacy,
       WebSocketOpenConnectionCallback ws_open_callback,
       WebSocketNewIPPacketCallback ws_new_ippacket_callback,
       WebSocketCloseConnectionCallback ws_close_callback);
@@ -58,6 +60,8 @@ class Listener final {
   HandshakeCacheManagerSPtr handshake_cache_manager_;
 
   const std::string server_external_ips_;
+  const std::vector<std::string> session_keys_;
+  const bool session_id_accept_legacy_;
 
   const WebSocketOpenConnectionCallback ws_open_callback_;
   const WebSocketNewIPPacketCallback ws_new_ippacket_callback_;

--- a/src/fptn-server/web/server.cpp
+++ b/src/fptn-server/web/server.cpp
@@ -33,6 +33,8 @@ Server::Server(std::uint16_t port,
     std::vector<std::string> allowed_sni_list,
     std::size_t max_active_sessions_per_user,
     std::string server_external_ips,
+    std::vector<std::string> session_keys,
+    bool session_id_accept_legacy,
     int thread_number)
     : running_(false),
       port_(port),
@@ -48,6 +50,8 @@ Server::Server(std::uint16_t port,
       allowed_sni_list_(std::move(allowed_sni_list)),
       max_active_sessions_per_user_(max_active_sessions_per_user),
       server_external_ips_(std::move(server_external_ips)),
+      session_keys_(std::move(session_keys)),
+      session_id_accept_legacy_(session_id_accept_legacy),
       thread_number_(std::max<std::size_t>(1, thread_number)),
       ioc_(thread_number),
       from_client_("packets_from_websockets", 1024 * 16) {
@@ -67,6 +71,8 @@ Server::Server(std::uint16_t port,
       enable_detect_probing_, default_proxy_domain_, allowed_sni_list_,
       // ioc
       ioc_, token_manager, handshake_cache_manager_, server_external_ips_,
+      // keyed session-id marker
+      session_keys_, session_id_accept_legacy_,
       // NOLINTNEXTLINE(modernize-avoid-bind)
       std::bind(
           &Server::HandleWsOpenConnection, this, _1, _2, _3, _4, _5, _6, _7),

--- a/src/fptn-server/web/server.h
+++ b/src/fptn-server/web/server.h
@@ -42,6 +42,8 @@ class Server final {
       std::vector<std::string> allowed_sni_list,
       std::size_t max_active_sessions_per_user,
       std::string server_external_ips,
+      std::vector<std::string> session_keys,
+      bool session_id_accept_legacy,
       int thread_number = 16);
   ~Server();
   bool Start();
@@ -97,6 +99,8 @@ class Server final {
 
   const std::size_t max_active_sessions_per_user_;
   const std::string server_external_ips_;
+  const std::vector<std::string> session_keys_;
+  const bool session_id_accept_legacy_;
   const std::size_t thread_number_;
 
   boost::asio::io_context ioc_;

--- a/src/fptn-server/web/session/session.cpp
+++ b/src/fptn-server/web/session/session.cpp
@@ -102,6 +102,8 @@ Session::Session(bool enable_detect_probing,
     std::string default_proxy_domain,
     std::vector<std::string> allowed_sni_list,
     std::string server_external_ips,
+    std::vector<std::string> session_keys,
+    bool session_id_accept_legacy,
     boost::asio::ip::tcp::socket&& socket,
     boost::asio::ssl::context& ctx,
     const ApiHandleMap& api_handles,
@@ -113,6 +115,8 @@ Session::Session(bool enable_detect_probing,
       default_proxy_domain_(std::move(default_proxy_domain)),
       allowed_sni_list_(std::move(allowed_sni_list)),
       server_external_ips_(std::move(server_external_ips)),
+      session_keys_(std::move(session_keys)),
+      session_id_accept_legacy_(session_id_accept_legacy),
       ws_(ssl_stream_type(
           obfuscator_socket_type(tcp_stream_type(std::move(socket))), ctx)),
       strand_(boost::asio::make_strand(ws_.get_executor())),
@@ -406,14 +410,14 @@ boost::asio::awaitable<Session::ProbingResult> Session::DetectProbing() {
 
     // Check Session ID
     const bool is_fptn_session_id =
-        protocol::https::utils::IsFptnClientSessionID(
-            session_id.data(), session_id.size());
+        protocol::https::utils::IsFptnClientSessionID(session_id.data(),
+            session_id.size(), session_keys_, session_id_accept_legacy_);
     const bool is_decoy_session_id =
-        protocol::https::utils::IsDecoyHandshakeSessionID(
-            session_id.data(), session_id.size());
+        protocol::https::utils::IsDecoyHandshakeSessionID(session_id.data(),
+            session_id.size(), session_keys_, session_id_accept_legacy_);
     const bool is_decoy_session_id2 =
-        protocol::https::utils::IsDecoyHandshakeSessionID2(
-            session_id.data(), session_id.size());
+        protocol::https::utils::IsDecoyHandshakeSessionID2(session_id.data(),
+            session_id.size(), session_keys_, session_id_accept_legacy_);
     if (!is_fptn_session_id && !is_decoy_session_id && !is_decoy_session_id2) {
       SPDLOG_ERROR(
           "Session ID does not match FPTN client format (client_id={})",
@@ -540,10 +544,11 @@ boost::asio::awaitable<Session::RealityResult> Session::IsRealityHandshake() {
     if (session_id.size() == kSessionLen) {
       // Check if it's a decoy handshake (reality mode)
       const bool is_reality = protocol::https::utils::IsDecoyHandshakeSessionID(
-          session_id.data(), session_id.size());
+          session_id.data(), session_id.size(), session_keys_,
+          session_id_accept_legacy_);
       const bool is_reality2 =
-          protocol::https::utils::IsDecoyHandshakeSessionID2(
-              session_id.data(), session_id.size());
+          protocol::https::utils::IsDecoyHandshakeSessionID2(session_id.data(),
+              session_id.size(), session_keys_, session_id_accept_legacy_);
       if (is_reality || is_reality2) {
         co_return RealityResult{.is_reality_mode = is_reality,
             .is_reality_mode2 = is_reality2,

--- a/src/fptn-server/web/session/session.h
+++ b/src/fptn-server/web/session/session.h
@@ -39,6 +39,8 @@ class Session : public std::enable_shared_from_this<Session> {
       std::string default_proxy_domain,
       std::vector<std::string> allowed_sni_list,
       std::string server_external_ips,
+      std::vector<std::string> session_keys,
+      bool session_id_accept_legacy,
       boost::asio::ip::tcp::socket&& socket,
       boost::asio::ssl::context& ctx,
       const ApiHandleMap& api_handles,
@@ -118,6 +120,8 @@ class Session : public std::enable_shared_from_this<Session> {
   const std::vector<std::string> allowed_sni_list_;
 
   const std::string server_external_ips_;
+  const std::vector<std::string> session_keys_;
+  const bool session_id_accept_legacy_;
 
   // TCP -> obfuscator -> SSL -> WebSocket
   using tcp_stream_type = boost::beast::tcp_stream;

--- a/tests/fptnlib/CMakeLists.txt
+++ b/tests/fptnlib/CMakeLists.txt
@@ -34,3 +34,8 @@ set(LIBS
 add_executable(ApiClientTest api_client/ApiClientTest.cpp)
 target_link_libraries(ApiClientTest PRIVATE ${LIBS})
 add_test(NAME ApiClientTest COMMAND ApiClientTest)
+
+# --- TLS keyed session-id marker test ---
+add_executable(TlsMarkerTest tls/TlsMarkerTest.cpp)
+target_link_libraries(TlsMarkerTest PRIVATE ${LIBS})
+add_test(NAME TlsMarkerTest COMMAND TlsMarkerTest)

--- a/tests/fptnlib/tls/TlsMarkerTest.cpp
+++ b/tests/fptnlib/tls/TlsMarkerTest.cpp
@@ -1,0 +1,139 @@
+/*=============================================================================
+Copyright (c) 2024-2026 Stas Skokov
+
+Distributed under the MIT License (https://opensource.org/licenses/MIT)
+=============================================================================*/
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "fptn-protocol-lib/https/utils/tls/tls.h"
+#include "fptn-protocol-lib/time/time_provider.h"
+
+namespace {
+
+namespace utils = fptn::protocol::https::utils;
+
+constexpr std::size_t kSessionLen = 32;
+constexpr std::size_t kFptnClientMarkerOffset = kSessionLen - 4;  // 28
+constexpr std::size_t kDecoyMarkerOffset = 10;
+constexpr std::size_t kDecoyMarkerOffset2 = 14;
+
+std::string ToHex(const std::string& s) {
+  static const char* h = "0123456789abcdef";
+  std::string o;
+  for (unsigned char c : s) {
+    o.push_back(h[c >> 4]);
+    o.push_back(h[c & 0x0F]);
+  }
+  return o;
+}
+
+// A 32-byte session_id with `marker` placed at `offset`.
+std::array<std::uint8_t, kSessionLen> MakeSessionId(
+    const std::string& marker, std::size_t offset) {
+  std::array<std::uint8_t, kSessionLen> id{};
+  std::memcpy(id.data() + offset, marker.data(), marker.size());
+  return id;
+}
+
+std::uint32_t Now() {
+  return fptn::time::TimeProvider::Instance()->NowTimestamp();
+}
+
+}  // namespace
+
+// The keyed marker matches an independently computed HMAC-SHA256 reference
+// (see the same vectors in Python: hmac.new(S, be32(ts), sha256)[:4]).
+TEST(TlsMarker, KeyedMatchesReferenceVectors) {
+  EXPECT_EQ(ToHex(utils::GenerateFptnKeyKeyed(1700000000, "test-shared-secret")),
+      "486cd553");
+  EXPECT_EQ(ToHex(utils::GenerateFptnKeyKeyed(1700000000, "S1")), "88a221b0");
+  EXPECT_EQ(ToHex(utils::GenerateFptnKeyKeyed(1700000000, "S2")), "1425e0a1");
+  // Legacy marker is the unkeyed SHA1(be32(ts))[:4].
+  EXPECT_EQ(ToHex(utils::GenerateFptnKey(1700000000)), "f18b7fe9");
+}
+
+TEST(TlsMarker, KeyedProperties) {
+  EXPECT_EQ(utils::GenerateFptnKeyKeyed(1700000000, "S1").size(), 4u);
+  EXPECT_NE(utils::GenerateFptnKeyKeyed(1700000000, "S1"),
+      utils::GenerateFptnKey(1700000000));
+  EXPECT_NE(utils::GenerateFptnKeyKeyed(1700000000, "S1"),
+      utils::GenerateFptnKeyKeyed(1700000000, "S2"));
+  EXPECT_EQ(utils::GenerateFptnKeyKeyed(1700000000, "S1"),
+      utils::GenerateFptnKeyKeyed(1700000000, "S1"));
+  EXPECT_NE(utils::GenerateFptnKeyKeyed(1700000000, "S1"),
+      utils::GenerateFptnKeyKeyed(1700000005, "S1"));
+}
+
+// Server-side validation of the primary (obfuscation-less) client marker.
+TEST(TlsMarker, ServerValidatesFptnClientMarker) {
+  const std::string kSecret = "test-shared-secret";
+  const std::uint32_t now = Now();
+
+  const auto keyed =
+      MakeSessionId(utils::GenerateFptnKeyKeyed(now, kSecret),
+          kFptnClientMarkerOffset);
+  const auto legacy =
+      MakeSessionId(utils::GenerateFptnKey(now), kFptnClientMarkerOffset);
+
+  // keyed marker accepted when the secret is known (with or without legacy).
+  EXPECT_TRUE(utils::IsFptnClientSessionID(
+      keyed.data(), keyed.size(), {kSecret}, true));
+  EXPECT_TRUE(utils::IsFptnClientSessionID(
+      keyed.data(), keyed.size(), {kSecret}, false));
+  // wrong / missing secret rejected.
+  EXPECT_FALSE(utils::IsFptnClientSessionID(
+      keyed.data(), keyed.size(), {"other"}, false));
+  EXPECT_FALSE(
+      utils::IsFptnClientSessionID(keyed.data(), keyed.size(), {}, false));
+
+  // legacy marker: accepted only while accept_legacy is on.
+  EXPECT_TRUE(utils::IsFptnClientSessionID(
+      legacy.data(), legacy.size(), {kSecret}, true));
+  EXPECT_FALSE(utils::IsFptnClientSessionID(
+      legacy.data(), legacy.size(), {kSecret}, false));
+  // pure-legacy deployment (no keys configured) keeps working.
+  EXPECT_TRUE(
+      utils::IsFptnClientSessionID(legacy.data(), legacy.size(), {}, true));
+}
+
+// Key rotation: server accepts any of several configured keys.
+TEST(TlsMarker, ServerAcceptsRotatedKeys) {
+  const std::uint32_t now = Now();
+  const std::vector<std::string> keys{"S1", "S2"};
+  for (const auto& k : keys) {
+    const auto id =
+        MakeSessionId(utils::GenerateFptnKeyKeyed(now, k),
+            kFptnClientMarkerOffset);
+    EXPECT_TRUE(utils::IsFptnClientSessionID(id.data(), id.size(), keys, false))
+        << "rotated key not accepted: " << k;
+  }
+}
+
+// The two decoy/reality marker positions validate the same way.
+TEST(TlsMarker, ServerValidatesDecoyMarkers) {
+  const std::string kSecret = "test-shared-secret";
+  const std::uint32_t now = Now();
+
+  const auto decoy1 =
+      MakeSessionId(utils::GenerateFptnKeyKeyed(now, kSecret),
+          kDecoyMarkerOffset);
+  EXPECT_TRUE(utils::IsDecoyHandshakeSessionID(
+      decoy1.data(), decoy1.size(), {kSecret}, false));
+  EXPECT_FALSE(utils::IsDecoyHandshakeSessionID(
+      decoy1.data(), decoy1.size(), {"other"}, false));
+
+  const auto decoy2 =
+      MakeSessionId(utils::GenerateFptnKeyKeyed(now, kSecret),
+          kDecoyMarkerOffset2);
+  EXPECT_TRUE(utils::IsDecoyHandshakeSessionID2(
+      decoy2.data(), decoy2.size(), {kSecret}, false));
+  EXPECT_FALSE(utils::IsDecoyHandshakeSessionID2(
+      decoy2.data(), decoy2.size(), {"other"}, false));
+}


### PR DESCRIPTION
The stealth marker that the server uses to tell an FPTN client apart from an unrelated connection is embedded in the TLS session_id and is currently GenerateFptnKey = SHA1(timestamp)[0:4] -- no secret. Any on-path observer can recompute SHA1(now +/- 5s)[0:4] and passively fingerprint FPTN, or craft a valid marker and actively probe a host to confirm it runs FPTN. The probing gate is pre-auth, so the marker alone flips server behavior.

Introduce a keyed marker:

    marker = HMAC-SHA256(S, be32(timestamp))[0:4]

where S is a deployment-wide shared secret configured on the server and distributed to clients in the connection token. Without S the marker is indistinguishable from the random bytes browsers already put in session_id, so a single ClientHello no longer identifies FPTN.

Server (fptn-server):
  --session-key <s[,s2,...]>   one or more accepted secrets; multiple keys
                               allow rotation (roll out the new key, then
                               retire the old one).
  --session-id-accept-legacy   (default true) also accept the old unkeyed
                               marker during migration; set false to require
                               keyed markers and close the fingerprint.
The keys/flag thread ServerConfig -> Server -> Listener -> Session and feed
the IsFptnClientSessionID / IsDecoyHandshakeSessionID(2) validators.

Client (cli + gui):
  Token gains an optional service-level "session_key". It is carried
  per-server on ServerInfo / WebsocketClient::Config (like md5_fingerprint)
  and passed to SetHandshakeSessionID and the decoy/reality generators
  (GenerateDecoyTlsHandshake, GenerateDecoyTlsSessionId2).

Fully backward compatible: an empty secret -> legacy marker, and tokens without session_key keep working. With --session-id-accept-legacy=false a deployment using Reality mode should first ship keyed clients, since the decoy markers are keyed the same way.

Adds tests/fptnlib/tls/TlsMarkerTest.cpp (reference vectors, dual-accept, rotation, decoy offsets).