### PR TITLE
fix(client): keep split-tunnel DNS routes across a reconnect

### DIFF
--- a/src/fptn-client/routing/route_manager.cpp
+++ b/src/fptn-client/routing/route_manager.cpp
@@ -582,13 +582,20 @@ pass out on {tunInterfaceName} proto tcp from any to any port 53
 
   const bool status = AddExcludeNetworks(config_.exclude_networks) &&
                       AddIncludeNetworks(config_.include_networks);
+
+  // Restore split-tunnel routes resolved from DNS before a reconnect (kept by
+  // Clean(keep_dns_routes=true)). Without this they stay gone until each domain
+  // is looked up again, so cached destinations wrongly fall back to the VPN.
+  ReapplyDnsRoutes();
+
   if (status) {
     SPDLOG_INFO("=== Routing setup completed successfully ===");
   }
   return status;
 }
 
-bool RouteManager::Clean() {  // NOLINT(bugprone-exception-escape)
+bool RouteManager::Clean(  // NOLINT(bugprone-exception-escape)
+    bool keep_dns_routes) {
   if (!running_) {
     SPDLOG_INFO("No need to clean rules!");
     return true;
@@ -617,7 +624,11 @@ bool RouteManager::Clean() {  // NOLINT(bugprone-exception-escape)
     del_commands.push_back(BuildRemoveIPv4RouteCommand(
         ip.destination, config_.gateway_ipv4.ToString(), interface_name));
   }
-  dns_routes_ipv4_.clear();
+  // On a reconnect the entries are kept so Apply() can re-install them without
+  // waiting for each domain to be resolved again.
+  if (!keep_dns_routes) {
+    dns_routes_ipv4_.clear();
+  }
 
   // clean dns ipv6
   for (const auto& ip : dns_routes_ipv6_) {
@@ -636,7 +647,9 @@ bool RouteManager::Clean() {  // NOLINT(bugprone-exception-escape)
     del_commands.push_back(BuildRemoveIPv6RouteCommand(
         ip.destination, config_.gateway_ipv6.ToString(), interface_name));
   }
-  dns_routes_ipv6_.clear();
+  if (!keep_dns_routes) {
+    dns_routes_ipv6_.clear();
+  }
 
   // clean route ipv4
   for (const auto& route : additional_routes_ipv4_) {
@@ -863,6 +876,58 @@ bool RouteManager::Clean() {  // NOLINT(bugprone-exception-escape)
   }
   running_ = false;
   return true;
+}
+
+void RouteManager::ReapplyDnsRoutes() {
+  // Called from Apply(), which already holds mutex_; do not lock again. The
+  // route-add helpers do not touch the dns_routes_* sets, so iterating them
+  // directly is safe.
+  if (dns_routes_ipv4_.empty() && dns_routes_ipv6_.empty()) {
+    return;
+  }
+
+  for (const auto& entry : dns_routes_ipv4_) {
+    std::string interface_name;
+    std::string gateway_ip;
+    if (entry.policy == RoutingPolicy::kExcludeFromVpn) {
+      interface_name = !detected_out_interface_name_.empty()
+                           ? detected_out_interface_name_
+                           : config_.out_interface_name;
+      gateway_ip = config_.gateway_ipv4.ToString();
+    } else {
+      interface_name = tun_interface_name_;
+      gateway_ip = config_.tun_interface_address_ipv4.ToString();
+    }
+    if (interface_name.empty()) {
+      interface_name = GetDefaultNetworkInterfaceName();
+    }
+    if (interface_name.empty()) {
+      continue;
+    }
+    AddIPv4RouteToSystem(entry.destination, gateway_ip, interface_name);
+  }
+
+  for (const auto& entry : dns_routes_ipv6_) {
+    std::string interface_name;
+    std::string gateway_ip;
+    if (entry.policy == RoutingPolicy::kExcludeFromVpn) {
+      interface_name = !detected_out_interface_name_.empty()
+                           ? detected_out_interface_name_
+                           : config_.out_interface_name;
+      gateway_ip = config_.gateway_ipv6.ToString();
+    } else {
+      interface_name = tun_interface_name_;
+      gateway_ip = config_.tun_interface_address_ipv6.ToString();
+    }
+    if (interface_name.empty() || gateway_ip.empty()) {
+      continue;
+    }
+    AddIPv6RouteToSystem(entry.destination, gateway_ip, interface_name);
+  }
+
+  SPDLOG_INFO("Reapplied split-tunnel DNS routes after reconnect: {} IPv4, {} "
+              "IPv6",
+      dns_routes_ipv4_.size(), dns_routes_ipv6_.size());
 }
 
 bool RouteManager::AddDnsRoutesIPv4(

--- a/src/fptn-client/routing/route_manager.h
+++ b/src/fptn-client/routing/route_manager.h
@@ -75,7 +75,7 @@ class RouteManager final {
   ~RouteManager();
 
   bool Apply(std::string tun_name);
-  bool Clean();
+  bool Clean(bool keep_dns_routes = false);
 
   bool AddDnsRoutesIPv4(
       const std::vector<fptn::common::network::IPv4Address>& ips,
@@ -88,6 +88,11 @@ class RouteManager final {
  protected:
   bool AddExcludeNetworks(const std::vector<std::string>& networks);
   bool AddIncludeNetworks(const std::vector<std::string>& networks);
+
+  // Re-install split-tunnel host routes previously resolved from DNS. Called by
+  // Apply() so domain routes survive a reconnect instead of being lost until
+  // each domain is looked up again.
+  void ReapplyDnsRoutes();
 
  private:
   mutable std::mutex mutex_;

--- a/src/fptn-client/vpn/vpn_manager.cpp
+++ b/src/fptn-client/vpn/vpn_manager.cpp
@@ -334,7 +334,10 @@ void VpnManager::Supervise() {
         "Full VPN restart {}/{}", full_restart_count, kMaxFullRestarts_);
 
     config_.http_client->Stop();
-    config_.route_manager->Clean();
+    // Keep split-tunnel DNS routes so Apply() can restore them right after the
+    // tunnel comes back, instead of losing them until every domain is resolved
+    // again (which sent cached split-tunnel destinations through the VPN).
+    config_.route_manager->Clean(/*keep_dns_routes=*/true);
     fptn::time::TimeProvider::Instance()->SyncWithNtp();
 
     {


### PR DESCRIPTION
In domain-based split-tunnel mode some destinations that should bypass the VPN intermittently start going through the tunnel instead. In my setup .ru sites like ozon.ru and 2ip.ru would randomly begin exiting via the VPN and then recover on their own a while later.

The split-tunnel host routes discovered from DNS live in RouteManager::dns_routes_ipv4_/ipv6_ and are added on the fly by AddDnsRoutesIPv4/IPv6. The server drops the session every few hours (I see a websocket timeout roughly every ~3h), and on each disconnect Supervise() does a full restart: Clean() then Apply(). Clean() deletes and clears the dns_routes_* sets, but Apply() only re-adds the static exclude/include networks from config -- it never restores the domain routes. So after a reconnect a /32 comes back only once that domain is resolved again; domains still sitting in a client's DNS cache have no direct route and fall back to the VPN default until their TTL expires. The IP-based EXCLUDE_TUNNEL_NETWORKS don't hit this because Apply() re-adds them right away, which is why only the domain routes leaked.

The fix keeps the DNS routes across a reconnect instead of rebuilding them lazily:

    Clean(keep_dns_routes=true)    // reconnect teardown: drop system routes, keep the entries
    Apply() -> ReapplyDnsRoutes()  // re-install the kept entries once the tunnel is back

Only the reconnect path in Supervise() passes keep_dns_routes=true; full shutdown and the give-up path keep the original full clear. ReapplyDnsRoutes() runs under the lock Apply() already holds (like AddExcludeNetworks) and reuses the same interface/gateway selection as AddDnsRoutes*. During the reconnect window Clean() already restores the direct default route, so nothing leaks while the tunnel is down, and the split-tunnel routes are back the moment Apply() finishes -- no waiting on a fresh DNS query.

I confirmed the root cause on a live Linux client (PPPoE, exclude mode): the journal shows the ~3h websocket timeout and Full VPN restart, each followed by a bulk `ip route del` of the split-tunnel /32s, after which a cached .ru address resolves to the tun0 default until it's looked up again.

Heads up: I haven't built or run this branch yet -- it's by code inspection against that flow. It needs a Linux build plus a forced-reconnect check that the routes come back without a new DNS query, and a look at the macOS/Windows re-add paths (same AddIPv4/IPv6RouteToSystem helpers). Happy to iterate.
